### PR TITLE
いくつか不具合を修正しています。

### DIFF
--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -10,7 +10,7 @@
         <div style= 'text-align: center;'>
           <h2 class= 'font-weight-bold m-1'><%= @item.name %></h2>
           <div><%= @item.introduction %></div>
-          <div class= 'm-3 font-weight-bold'><span>¥</span><%= @item.number_to_currency %><span>(税込)</span></div>
+          <div class= 'm-3 font-weight-bold'><span>¥</span><%= @item.with_tax_price.to_s(:delimited) %><span>(税込)</span></div>
           <div class= 'm-3'><%= f.select :quantity, *[1..50] %></div>
           <div><%= f.hidden_field :item_id, :value => @item.id %></div>
           <div><%= f.submit "カートに入れる", class: "btn btn-success"%></div>

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -30,7 +30,7 @@
               <td class="text-right"><%= f.radio_button :address_option, 1 %></td>
               <td>
                 <%= f.label :order_address, "登録済住所から選択" %></br>
-                <%= f.collection_select :member_id, @addresses, :id, :address %></br>
+                <%= f.collection_select :member_id, @addresses, :id, :address_display %></br>
               </td>
             </tr>
             <tr>

--- a/app/views/public/orders/show.html.erb
+++ b/app/views/public/orders/show.html.erb
@@ -43,12 +43,10 @@
                 <td class= 'table-secondary' scope="col" style="width: 40%">商品合計</td>
                 <% order_items_total = 0 %>
                 <!--注文商品全部を合わせた時の価格を求めています。-->
-                <td class= 'bg-white'>
-                  <% @order_items.each do |o| %>
-                  <% order_items_total += o.tax_in_price %>
+                  <% @order_items.each do |item| %>
+                  <% order_items_total += (item.tax_in_price*item.quantity) %>
                   <% end %>
-                  <%= order_items_total.floor.to_s(:delimited) %>
-                </td>
+                  <td class= 'bg-white'><%= order_items_total.floor.to_s(:delimited) %></td>
               </tr>
                 <!--配送料-->
               <tr class= 'table-bordered'>


### PR DESCRIPTION
改めてテストを実施した時に発見した不具合を修正しています。

①注文詳細画面の商品合計が、商品１つ分の値しか出されていない
　　⇒計算コードの見直しを行い修正

②注文入力画面の登録済みの住所が、住所のみの表示になっている
　⇒郵便番号、住所、宛名も表示されるように修正

③商品詳細画面の値段表記が「税抜」価格になっている
　⇒「税込」価格になるようにコード修正